### PR TITLE
refactor: refactor command runner to use yargs

### DIFF
--- a/lib/Snapshot.mjs
+++ b/lib/Snapshot.mjs
@@ -3,7 +3,6 @@ import { $, YAML, chalk } from 'zx'
 class Snapshot {
   constructor (argv) {
     this.argv = argv
-    this.help = argv.help || false
     this.app = argv.app || argv.a || process.env.APP
     this.namespace = argv.namespace || argv.n || process.env.NAMESPACE
     this.kopiaApp = argv['kopia-app'] || process.env.KOPIA_APP || 'kopia'
@@ -65,11 +64,6 @@ class Snapshot {
   }
 
   async list () {
-    if (this.help) {
-      console.log('Usage: ' + chalk.cyanBright('ctl snapshot list --app <app> --namespace <namespace> --kopia-app <kopia-app> --kopia-namespace <kopia-namespace>'))
-      return process.exit(0)
-    }
-
     const snapshots = await $`kubectl -n ${this.kopiaNamespace} exec -it deployment/${this.kopiaApp} -- kopia snapshot list /data/${this.namespace}/${this.app} --json`
     const structData = []
     for (const obj of JSON.parse(snapshots.stdout)) {
@@ -84,10 +78,6 @@ class Snapshot {
   }
 
   async create () {
-    if (this.help) {
-      console.log('Usage: ' + chalk.cyanBright('ctl snapshot create --app <app> --namespace <namespace>'))
-      return process.exit(0)
-    }
     const jobRaw = await $`kubectl -n ${this.namespace} create job --from=cronjob/${this.app}-snapshot ${this.app}-snapshot-${+new Date()} --dry-run=client --output json`
     const jobJson = JSON.parse(jobRaw.stdout)
     delete jobJson.spec.template.spec.initContainers

--- a/lib/Snapshot.mjs
+++ b/lib/Snapshot.mjs
@@ -1,8 +1,8 @@
-import { argv, $, YAML, chalk } from 'zx'
+import { $, YAML, chalk } from 'zx'
 
 class Snapshot {
-  constructor (...args) {
-    this.args = args
+  constructor (argv) {
+    this.argv = argv
     this.help = argv.help || false
     this.app = argv.app || argv.a || process.env.APP
     this.namespace = argv.namespace || argv.n || process.env.NAMESPACE
@@ -16,7 +16,7 @@ class Snapshot {
       return console.error('Error: ' + chalk.redBright('Argument --namespace, -n or env NAMESPACE not set'))
     }
 
-    switch (this.args[0]) {
+    switch (argv.action) {
       case 'list':
         this.list()
         break
@@ -24,8 +24,43 @@ class Snapshot {
         this.create()
         break
       default:
-        console.error('404: ' + chalk.redBright(`${args[0]} arg not found`))
+        console.error('404: ' + chalk.redBright(`${argv.action} arg not found`))
         break
+    }
+  }
+
+  static yargsCommand = {
+    command: 'snapshot <action>',
+    desc: 'Manage snapshots',
+    strictCommands: true,
+    builder: (yargs) => yargs
+      .positional('action', {
+        choices: ['create', 'list']
+      })
+      .option('app', {
+        alias: ['a'],
+        demandOption: true,
+        type: 'string',
+        desc: 'The app'
+      })
+      .option('namespace', {
+        alias: ['n'],
+        demandOption: true,
+        type: 'string',
+        desc: 'The namespace for the snapshot'
+      })
+      .option('kopia-app', {
+        type: 'string',
+        desc: 'The name of the kopia app',
+        default: 'kopia'
+      })
+      .option('kopia-namespace', {
+        type: 'string',
+        desc: 'The namespace of kopia',
+        default: 'default'
+      }),
+    handler: (argv) => {
+      return new Snapshot(argv)
     }
   }
 

--- a/lib/commandRunner.mjs
+++ b/lib/commandRunner.mjs
@@ -1,16 +1,41 @@
 import * as lib from './index.js'
 import { chalk } from 'zx'
+import yargs from 'yargs'
 
 const commandRunner = (cmd, ...args) => {
-  if (!cmd) {
-    return console.error('Error: ' + chalk.redBright('No command was entered'))
+  const builder = yargs()
+    .scriptName('gluctl')
+    .usage('$0 <cmd> [args]')
+    // enable parsing env vars (no prefix specified)
+    .env()
+    // error out when no command is given
+    .demandCommand(1, 'No command was entered')
+    // error out when given an unnknown command
+    .strictCommands()
+    // enable help menus
+    .help()
+    // enable shorthand help argument
+    .alias('help', 'h')
+    // enable completion
+    .completion()
+    // customize failure message to add some color
+    .fail((msg, err, yargs) => {
+      if (err) throw err // preserve stack
+      console.error(yargs.help(), '\n')
+      console.error(chalk.redBright(msg))
+      process.exit(1)
+    })
+
+  // iterate over lib and add the commands
+  for (cmd in lib) {
+    if (typeof lib[cmd].yargsCommand === 'object') {
+      builder.command(lib[cmd].yargsCommand)
+    }
   }
 
-  if (!lib[cmd]) {
-    return console.error('404: ' + chalk.redBright(`${cmd} cmd not found`))
-  }
-
-  return new lib[cmd](args)
+  // normally it would be slice 2 (node, ./gluctl, args), but with zx we needed slice 3 (node, zx, ./gluctl, args)
+  // ...but probably need to be smarter about this?
+  builder.parse(process.argv.slice(3))
 }
 
 export { commandRunner }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "version": "0.0.1",
   "main": "gluctl",
-  "license" : "SEE LICENSE IN LICENSE.md",
+  "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/onedr0p/gluctl"
@@ -29,6 +29,7 @@
     "standard": "^17.0.0"
   },
   "dependencies": {
+    "yargs": "^17.5.1",
     "zx": "^7.0.7"
   }
 }


### PR DESCRIPTION
yargs brings with it built-in help responses, tab completion, etc.

Examples:
```
❯ ./gluctl --help
gluctl <cmd> [args]

Commands:
  gluctl completion         generate completion script
  gluctl snapshot <action>  Manage snapshots

Options:
      --version  Show version number                                   [boolean]
  -h, --help     Show help                                             [boolean]
```

```
❯ ./gluctl snapshot --help
gluctl snapshot <action>

Manage snapshots

Positionals:
  action                                  [required] [choices: "create", "list"]

Options:
      --version          Show version number                           [boolean]
  -h, --help             Show help                                     [boolean]
  -a, --app              The app                             [string] [required]
  -n, --namespace        The namespace for the snapshot      [string] [required]
      --kopia-app        The name of the kopia app   [string] [default: "kopia"]
      --kopia-namespace  The namespace of kopia    [string] [default: "default"]
```

```
❯ ./gluctl snapshot list
gluctl snapshot <action>

Manage snapshots

Positionals:
  action                                  [required] [choices: "create", "list"]

Options:
      --version          Show version number                           [boolean]
  -h, --help             Show help                                     [boolean]
  -a, --app              The app                             [string] [required]
  -n, --namespace        The namespace for the snapshot      [string] [required]
      --kopia-app        The name of the kopia app   [string] [default: "kopia"]
      --kopia-namespace  The namespace of kopia    [string] [default: "default"] 

Missing required argument: app
```

I haven't actually setup any of this kopia stuff yet, but will probably be looking at it to switch off k10, so I get errors, but just to show that we are still getting into the command, here's what that looks like for me.
```
❯ ./gluctl snapshot list --app foo
file:///Users/brandencash/projects/gluctl/node_modules/zx/build/core.js:140
            let output = new ProcessOutput(code, signal, stdout, stderr, combined, message);
                         ^

ProcessOutput [Error]: Error from server (NotFound): deployments.apps "kopia" not found
    at Snapshot.list (file:///Users/brandencash/projects/gluctl/lib/Snapshot.mjs:73:30)
    exit code: 1
    at ChildProcess.<anonymous> (file:///Users/brandencash/projects/gluctl/node_modules/zx/build/core.js:140:26)
    at ChildProcess.emit (node:events:513:28)
    at ChildProcess.emit (node:domain:482:12)
    at maybeClose (node:internal/child_process:1091:16)
    at Socket.<anonymous> (node:internal/child_process:449:11)
    at Socket.emit (node:events:513:28)
    at Socket.emit (node:domain:482:12)
    at Pipe.<anonymous> (node:net:757:14)
    at Pipe.callbackTrampoline (node:internal/async_hooks:130:17) {
  _code: 1,
  _signal: null,
  _stdout: '',
  _stderr: 'Error from server (NotFound): deployments.apps "kopia" not found\n',
  _combined: 'Error from server (NotFound): deployments.apps "kopia" not found\n'
}

Node.js v18.6.0
```